### PR TITLE
normalize the path before adding to unique_matches.

### DIFF
--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -519,6 +519,7 @@ def find_resource(pkg, resource_name, filter_fn=None, rospack=None):
     # Uniquify the results, in case we found the same file twice, while keeping order
     unique_matches = []
     for match in matches:
-        if match not in unique_matches:
-            unique_matches.append(match)
+        norm_match = os.path.normcase(os.path.normpath(match))
+        if norm_match not in unique_matches:
+            unique_matches.append(norm_match)
     return unique_matches


### PR DESCRIPTION
Here is an example errors when it is happening.
```
c:\rviz_ws>roslaunch turtlebot3_fake turtlebot3_fake.launch
RLException: multiple files named [turtlebot3_fake.launch] in package [turtlebot3_fake]:
- C:\rviz_ws\install_isolated\share\turtlebot3_fake\launch\turtlebot3_fake.launch
- c:\rviz_ws\install_isolated\share\turtlebot3_fake\launch\turtlebot3_fake.launch
Please specify full path instead
The traceback for the exception was written to the log file
```

In the below code section, `search_path` and `pkg_path` could be pointed to the same location and the same file will be added to `matches`. Without normalizing, the following unique_matches cannot be handled correctly if the paths are mixing upper/lower cases and forward/backward slashes.
```Python
    for search_path in search_paths:
        matches.extend(_find_resource(search_path, resource_name, filter_fn=filter_fn))

    matches.extend(_find_resource(pkg_path, resource_name, filter_fn=filter_fn))
```